### PR TITLE
Made the image titles appear

### DIFF
--- a/Travel Scheduler/Views/AttractionCollectionCell.h
+++ b/Travel Scheduler/Views/AttractionCollectionCell.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) Place *place;
 @property (strong, nonatomic) NSMutableArray *selectedPlacesArray;
 @property (nonatomic, weak) id<AttractionCollectionCellDelegate> delegate;
+@property (nonatomic, strong) UILabel *titleLabel;
 
 - (void)setImage;
 @end

--- a/Travel Scheduler/Views/AttractionCollectionCell.m
+++ b/Travel Scheduler/Views/AttractionCollectionCell.m
@@ -11,6 +11,7 @@
 #import "TravelSchedulerHelper.h"
 #import "Date.h"
 #import "UIImageView+AFNetworking.h"
+#import <QuartzCore/QuartzCore.h>
 
 #pragma mark - UI initiation
 
@@ -32,20 +33,47 @@ static void makeSelected(UIImageView *imageView, Place *place)
     }
 }
 
+static void instantiateImageViewTitle(UILabel *titleLabel, Place *place)
+{
+    [titleLabel setFont: [UIFont fontWithName:@"Arial-BoldMT" size:15]];
+    titleLabel.text = place.name;
+    titleLabel.textColor = [UIColor whiteColor];
+    titleLabel.numberOfLines = 2;
+    titleLabel.layer.shadowColor = [UIColor colorWithRed:0 green:0 blue:0 alpha:1].CGColor;
+    titleLabel.layer.shadowOffset = CGSizeMake(0.0, 0.0);
+    titleLabel.layer.shadowRadius = 3.0;
+    titleLabel.layer.shadowOpacity = 1;
+    titleLabel.layer.masksToBounds = NO;
+    [titleLabel sizeToFit];
+    titleLabel.layer.shouldRasterize = YES;
+}
+
 @implementation AttractionCollectionCell
 
 #pragma mark - AttractionCollectionCell lifecycle
-
+    
 - (void)setImage
 {
-    self.imageView =[[UIImageView alloc] initWithFrame:CGRectMake(0,0,self.contentView.bounds.size.width,self.contentView.bounds.size.height)];
+    self.imageView = [[UIImageView alloc] initWithFrame:CGRectMake(0,0,self.contentView.bounds.size.width,self.contentView.bounds.size.height)];
+    self.titleLabel = [[UILabel alloc] initWithFrame:CGRectMake(0,0,self.contentView.bounds.size.width - 14,20)];
+    [self adjustUILabelFrame];
     instantiateImageView(self.imageView, self.place);
+    instantiateImageViewTitle(self.titleLabel, self.place);
+    [self.imageView addSubview:self.titleLabel];
     [self instantiateGestureRecognizers];
     [self.contentView addSubview:self.imageView];
     makeSelected(self.imageView, self.place);
     if(self.selectedPlacesArray == nil) {
     self.selectedPlacesArray = [[NSMutableArray alloc] init];
     }
+}
+
+- (void)adjustUILabelFrame
+{
+    CGRect frame = self.titleLabel.frame;
+    frame.origin.y = self.contentView.bounds.size.height - self.titleLabel.frame.size.height - 20;//pass the Y cordinate
+    frame.origin.x = 7;//pass the X cordinate
+    self.titleLabel.frame= frame;
 }
 
 #pragma mark - tap action segue to details


### PR DESCRIPTION
Hey everyone!
I put the place titles on top of the images (with some shadow to make it easier to read).
I think it will still be good to make the one-line titles go a little bit to the bottom, but I was still not able to do that without breaking the app with the layout function. Well, for now this is how it looks like:
<img width="414" alt="Screen Shot 2019-07-26 at 6 37 37 PM" src="https://user-images.githubusercontent.com/44936262/61988337-db60ea00-afd4-11e9-99c5-d2f3f8404a32.png">
