### PR TITLE
Feature/adding commutes between indirect places

### DIFF
--- a/Travel Scheduler/Helper Files/TravelSchedulerHelper.h
+++ b/Travel Scheduler/Helper Files/TravelSchedulerHelper.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+@class Place;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface TravelSchedulerHelper : NSObject
@@ -48,6 +50,7 @@ UIImageView *makeImage(NSURL *placeUrl);
 CAShapeLayer *makeDashedLine(int yStart, int xCoord, CAShapeLayer *shapeLayer);
 NSString *getStringFromTimeBlock(TimeBlock timeBlock);
 UILabel *makeTimeRangeLabel(NSString *text, int size);
+void getDistanceToHome(Place *place, Place *home);
 
 @end
 

--- a/Travel Scheduler/Helper Files/TravelSchedulerHelper.m
+++ b/Travel Scheduler/Helper Files/TravelSchedulerHelper.m
@@ -142,6 +142,15 @@ float getMin(float num1, float num2)
     return (num1 > num2) ? num2 : num1;
 }
 
+void getDistanceToHome(Place *place, Place *home)
+{
+    Commute *commuteInfo = [[Commute alloc] initWithOrigin:place.placeId toDestination:home.placeId withDepartureTime:0];
+    commuteInfo.origin = place;
+    commuteInfo.destination = home;
+    place.commuteFrom = commuteInfo;
+    place.travelTimeFromPlace = commuteInfo.durationInSeconds;
+}
+
 @implementation TravelSchedulerHelper
 
 @end

--- a/Travel Scheduler/Test/Schedule.m
+++ b/Travel Scheduler/Test/Schedule.m
@@ -17,15 +17,6 @@
 
 #pragma mark - Algorithm helper methods
 
-static void getDistanceToHome(Place *place, Place *home)
-{
-    Commute *commuteInfo = [[Commute alloc] initWithOrigin:place.placeId toDestination:home.placeId withDepartureTime:0];
-    commuteInfo.origin = place;
-    commuteInfo.destination = home;
-    place.commuteFrom = commuteInfo;
-    place.travelTimeFromPlace = commuteInfo.durationInSeconds;
-}
-
 static NSArray *getAvailableFilteredArray(NSMutableArray *availablePlaces)
 {
     NSMutableArray *priorityItems = [[NSMutableArray alloc] init];

--- a/Travel Scheduler/View Controllers/Place.m
+++ b/Travel Scheduler/View Controllers/Place.m
@@ -109,7 +109,7 @@ typedef void (^getNearbyPlacesOfTypeDictionariesCompletion)(NSArray *, NSString 
     float travelTime = ([self.travelTimeToPlace floatValue] / 3600) + 10.0/60.0;
     float arrivalTime;
     float departureTime;
-    float indirectPrevTime = (self.indirectPrev) ? (self.indirectPrev.departureTime + travelTime) : -1;
+    float indirectPrevTime = (self.indirectPrev) ? (self.indirectPrev.departureTime + travelTime + 0.75) : -1;
     switch(timeBlock) {
         case TimeBlockBreakfast:
             arrivalTime = 9 + travelTime;
@@ -143,7 +143,7 @@ typedef void (^getNearbyPlacesOfTypeDictionariesCompletion)(NSArray *, NSString 
             departureTime = 20.5 - ([self.travelTimeFromPlace floatValue] / 3600);
             break;
     }
-    if (arrivalTime > departureTime) {
+    if (departureTime - arrivalTime < 0.5) {
         return false;
     }
     self.arrivalTime = arrivalTime;

--- a/Travel Scheduler/View Controllers/ScheduleViewController.m
+++ b/Travel Scheduler/View Controllers/ScheduleViewController.m
@@ -30,21 +30,6 @@ static int leftIndent = 75;
 static int numHoursInSchedule = 18;
 static int scheduleStartTime = 8;
 
-
-
-
-//DELETE LATER
-static void getDistanceToHome(Place *place, Place *home)
-{
-    Commute *commuteInfo = [[Commute alloc] initWithOrigin:place.placeId toDestination:home.placeId withDepartureTime:0];
-    commuteInfo.origin = place;
-    commuteInfo.destination = home;
-    place.commuteFrom = commuteInfo;
-    place.travelTimeFromPlace = commuteInfo.durationInSeconds;
-}
-
-
-
 #pragma mark - View/Label creation
 
 static UILabel *makeTimeLabel(int num)

--- a/Travel Scheduler/View Controllers/ScheduleViewController.m
+++ b/Travel Scheduler/View Controllers/ScheduleViewController.m
@@ -30,6 +30,21 @@ static int leftIndent = 75;
 static int numHoursInSchedule = 18;
 static int scheduleStartTime = 8;
 
+
+
+
+//DELETE LATER
+static void getDistanceToHome(Place *place, Place *home)
+{
+    Commute *commuteInfo = [[Commute alloc] initWithOrigin:place.placeId toDestination:home.placeId withDepartureTime:0];
+    commuteInfo.origin = place;
+    commuteInfo.destination = home;
+    place.commuteFrom = commuteInfo;
+    place.travelTimeFromPlace = commuteInfo.durationInSeconds;
+}
+
+
+
 #pragma mark - View/Label creation
 
 static UILabel *makeTimeLabel(int num)
@@ -50,47 +65,34 @@ static UILabel *makeTimeLabel(int num)
     return label;
 }
 
-static UIView* makeLine()
+static UIView *makeLine()
 {
     UIView *view = [[UIView alloc] init];
     view.backgroundColor = [UIColor lightGrayColor];
     return view;
 }
 
-//NOTE: Times are formatted so that 12.5 = 12:30 and 12.25 = 12:15
-//NOTE: Times must also be in military time
-static PlaceView* makePlaceView(Place *place, float overallStart, int width, int yShift, Place *home)
+static void createTravelView(float yCoord, float height, float width, Place *place, PlaceView *placeView, PlaceView *prevPlaceView)
 {
-    float startTime = place.arrivalTime;
-    float endTime = place.departureTime;
-    float height = 100 * (endTime - startTime);
-    float yCoord = startY + (100 * (startTime - overallStart)) + yShift;
-    if (height < 50) {
-        return nil;
+    TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, yCoord, width - 10, height) startPlace:place.prevPlace endPlace:place];
+    if (placeView) {
+        placeView.travelPathTo = travelView;
     }
-    PlaceView *view = [[PlaceView alloc] initWithFrame:CGRectMake(leftIndent + 10, yCoord, width - 10, height) andPlace:place];
-    place.placeView = view;
-    if (place.prevPlace && (place.prevPlace != home)) {
-        int prevPlaceYCoord = startY + (100 * (place.prevPlace.departureTime - overallStart));
-        TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, prevPlaceYCoord + yShift, width - 10, yCoord - prevPlaceYCoord - yShift) startPlace:place.prevPlace endPlace:place];
-        view.travelPathTo = travelView;
-        place.prevPlace.placeView.travelPathFrom = travelView;
-    } else if (place.scheduledTimeBlock == TimeBlockBreakfast) {
-        TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, startY + (100 * (9 - overallStart)) + yShift, width - 10, yCoord - (startY + (100 * (9 - overallStart))) - yShift) startPlace:place.prevPlace endPlace:place];
-        view.travelPathTo = travelView;
-    } else if (place.indirectPrev) {
-        int height = (([place.travelTimeToPlace floatValue] / 3600) + 10.0/60.0) * 100;
-        int yDeparture = startY + (100 * (place.arrivalTime - overallStart)) + yShift;
-        TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, yDeparture - height, width - 10, height) startPlace:place.prevPlace endPlace:place];
-        view.travelPathTo = travelView;
-        place.prevPlace.placeView.travelPathFrom = travelView;
+    if (prevPlaceView) {
+        prevPlaceView.travelPathFrom = travelView;
     }
-    if (place.scheduledTimeBlock == TimeBlockEvening && place != home) {
-        int height = (([place.travelTimeFromPlace floatValue] / 3600) + 10.0/60.0) * 100;
-        int yDeparture = startY + (100 * (place.departureTime - overallStart)) + yShift;
-        TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, yDeparture, width - 10, height) startPlace:place endPlace:nil];
-        view.travelPathFrom = travelView;
-    }
+}
+
+static UIView *createBlankView(TimeBlock time, float startY, float endY, float width)
+{
+    UIView *view = [[UIView alloc] initWithFrame:CGRectMake(leftIndent + 10, startY, width, endY - startY)];
+    view.backgroundColor = [[UIColor grayColor] colorWithAlphaComponent:0.6];
+    UILabel *label = [[UILabel alloc] init];
+    label.text = getStringFromTimeBlock(time);
+    [label setFont: [UIFont fontWithName:@"Gotham-Light" size:15]];
+    [label sizeToFit];
+    label.frame = CGRectMake(CGRectGetWidth(view.frame) / 2 - CGRectGetWidth(label.frame) / 2, CGRectGetHeight(view.frame) / 2 - CGRectGetHeight(label.frame) / 2, CGRectGetWidth(label.frame), CGRectGetHeight(label.frame));
+    [view addSubview:label];
     return view;
 }
 
@@ -239,11 +241,9 @@ static PlaceView* makePlaceView(Place *place, float overallStart, int width, int
 }
 
 - (void)makePlaceSections {
-    int yShift = CGRectGetHeight(makeTimeLabel(12).frame) / 2;
-    int width = CGRectGetWidth(self.scrollView.frame) - leftIndent - 5;
     for (Place *place in self.dayPath) {
         if (place != self.home) {
-            PlaceView *view = makePlaceView(place, 8, width, yShift, self.hub);
+            PlaceView *view = [self makePlaceView:place];
             view.delegate = self;
             [self.scrollView addSubview:view];
             if (view.travelPathTo) {
@@ -254,9 +254,50 @@ static PlaceView* makePlaceView(Place *place, float overallStart, int width, int
                 [self.scrollView addSubview:view.travelPathFrom];
                 view.travelPathFrom.delegate = self;
             }
+        } else if ([self.dayPath indexOfObject:place] == 5 && [self.dayPath objectAtIndex:4] != self.home) {
+            Place *dinnerPlace = [self.dayPath objectAtIndex:TimeBlockDinner];
+            getDistanceToHome(dinnerPlace, self.home);
+            int height = (([dinnerPlace.travelTimeFromPlace floatValue] / 3600) + 10.0/60.0) * 100;
+            int yDeparture = startY + (100 * (dinnerPlace.departureTime - scheduleStartTime)) + CGRectGetHeight(makeTimeLabel(12).frame) / 2;
+            createTravelView(yDeparture, height, CGRectGetWidth(self.scrollView.frame) - leftIndent - 15, dinnerPlace, nil, dinnerPlace.placeView);
+            [self.scrollView addSubview:dinnerPlace.placeView.travelPathFrom];
         }
     }
 }
+
+- (PlaceView *)makePlaceView:(Place *)place
+{
+    int width = CGRectGetWidth(self.scrollView.frame) - leftIndent - 5;
+    int yShift = CGRectGetHeight(makeTimeLabel(12).frame) / 2;
+    float startTime = place.arrivalTime;
+    float endTime = place.departureTime;
+    float height = 100 * (endTime - startTime);
+    float yCoord = startY + (100 * (startTime - scheduleStartTime)) + yShift;
+    PlaceView *view = [[PlaceView alloc] initWithFrame:CGRectMake(leftIndent + 10, yCoord, width - 10, height) andPlace:place];
+    place.placeView = view;
+    if (place.prevPlace && (place.prevPlace != self.hub)) {
+        int prevPlaceYCoord = startY + (100 * (place.prevPlace.departureTime - scheduleStartTime));
+        createTravelView(prevPlaceYCoord + yShift, yCoord - prevPlaceYCoord - yShift, width - 10, place, place.placeView, place.prevPlace.placeView);
+    } else if (place.scheduledTimeBlock == TimeBlockBreakfast) {
+        createTravelView(startY + (100 * (9 - scheduleStartTime)) + yShift, yCoord - (startY + (100 * (9 - scheduleStartTime))) - yShift, width - 10, place, place.placeView, nil);
+    } else if (place.indirectPrev && (place.scheduledTimeBlock == getNextTimeBlock(getNextTimeBlock(place.indirectPrev.scheduledTimeBlock)))) {
+        float height = (([place.travelTimeToPlace floatValue] / 3600) + 10.0/60.0) * 100;
+        float yDeparture = startY + (100 * (place.arrivalTime - scheduleStartTime)) + yShift;
+        createTravelView(yDeparture - height, height, width - 10, place, place.placeView, place.prevPlace.placeView);
+        if (place.indirectPrev != self.home) {
+            float yPrevDeparture = startY + (100 * (place.indirectPrev.departureTime - scheduleStartTime)) + yShift;
+            UIView *blankView = createBlankView(getNextTimeBlock(place.indirectPrev.scheduledTimeBlock), yPrevDeparture, yDeparture - height, width - 10);
+            [self.scrollView addSubview:blankView];
+        }
+    }
+    if (place.scheduledTimeBlock == TimeBlockEvening) {
+        int height = (([place.travelTimeFromPlace floatValue] / 3600) + 10.0/60.0) * 100;
+        int yDeparture = startY + (100 * (place.departureTime - scheduleStartTime)) + yShift;
+        createTravelView(yDeparture, height, width - 10, place, nil, place.placeView);
+    }
+    return view;
+}
+
 
 #pragma mark - DateCell delegate
 

--- a/Travel Scheduler/View Controllers/ScheduleViewController.m
+++ b/Travel Scheduler/View Controllers/ScheduleViewController.m
@@ -59,7 +59,7 @@ static UIView* makeLine()
 
 //NOTE: Times are formatted so that 12.5 = 12:30 and 12.25 = 12:15
 //NOTE: Times must also be in military time
-static PlaceView* makePlaceView(Place *place, float overallStart, int width, int yShift, Place *hub)
+static PlaceView* makePlaceView(Place *place, float overallStart, int width, int yShift, Place *home)
 {
     float startTime = place.arrivalTime;
     float endTime = place.departureTime;
@@ -70,7 +70,7 @@ static PlaceView* makePlaceView(Place *place, float overallStart, int width, int
     }
     PlaceView *view = [[PlaceView alloc] initWithFrame:CGRectMake(leftIndent + 10, yCoord, width - 10, height) andPlace:place];
     place.placeView = view;
-    if (place.prevPlace && (place.prevPlace != hub)) {
+    if (place.prevPlace && (place.prevPlace != home)) {
         int prevPlaceYCoord = startY + (100 * (place.prevPlace.departureTime - overallStart));
         TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, prevPlaceYCoord + yShift, width - 10, yCoord - prevPlaceYCoord - yShift) startPlace:place.prevPlace endPlace:place];
         view.travelPathTo = travelView;
@@ -78,8 +78,14 @@ static PlaceView* makePlaceView(Place *place, float overallStart, int width, int
     } else if (place.scheduledTimeBlock == TimeBlockBreakfast) {
         TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, startY + (100 * (9 - overallStart)) + yShift, width - 10, yCoord - (startY + (100 * (9 - overallStart))) - yShift) startPlace:place.prevPlace endPlace:place];
         view.travelPathTo = travelView;
+    } else if (place.indirectPrev) {
+        int height = (([place.travelTimeToPlace floatValue] / 3600) + 10.0/60.0) * 100;
+        int yDeparture = startY + (100 * (place.arrivalTime - overallStart)) + yShift;
+        TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, yDeparture - height, width - 10, height) startPlace:place.prevPlace endPlace:place];
+        view.travelPathTo = travelView;
+        place.prevPlace.placeView.travelPathFrom = travelView;
     }
-    if (place.scheduledTimeBlock == TimeBlockEvening) {
+    if (place.scheduledTimeBlock == TimeBlockEvening && place != home) {
         int height = (([place.travelTimeFromPlace floatValue] / 3600) + 10.0/60.0) * 100;
         int yDeparture = startY + (100 * (place.departureTime - overallStart)) + yShift;
         TravelView *travelView = [[TravelView alloc] initWithFrame:CGRectMake(leftIndent + 10, yDeparture, width - 10, height) startPlace:place endPlace:nil];


### PR DESCRIPTION
Main changes:

- added travel times between two indirect places that are one time block away (only one place missing in between)
- added blank spaces for absent time blocks that are in between two scheduled ones
- fixed a small thing where if the last place is dinner and we couldn't fit an evening activity (seems to happen pretty often), the schedule would still show travel times to home

https://recordit.co/bv3CTXm6Dj
<img src='https://recordit.co/bv3CTXm6Dj.gif' title='Video Walkthrough' width='' alt='Video Walkthrough' />
