### PR TITLE
Features/back warning

### DIFF
--- a/Travel Scheduler.xcodeproj/project.pbxproj
+++ b/Travel Scheduler.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		7105E0BE22F2660400070DDC /* PlaceWebsiteViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7105E0BD22F2660400070DDC /* PlaceWebsiteViewController.m */; };
 		7105E0C422F4AFA400070DDC /* GoToMoreOptionsCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 7105E0C322F4AFA400070DDC /* GoToMoreOptionsCell.m */; };
 		7105E0CA22F93CC000070DDC /* PopUpView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7105E0C922F93CC000070DDC /* PopUpView.m */; };
+		7105E0CD22FA500500070DDC /* PopUpViewLateral.m in Sources */ = {isa = PBXBuildFile; fileRef = 7105E0CC22FA500500070DDC /* PopUpViewLateral.m */; };
+		7105E0D022FA51F200070DDC /* PopUpViewVertical.m in Sources */ = {isa = PBXBuildFile; fileRef = 7105E0CF22FA51F200070DDC /* PopUpViewVertical.m */; };
 		7115099B22DE923E00256219 /* APITesting.m in Sources */ = {isa = PBXBuildFile; fileRef = 7115099A22DE923E00256219 /* APITesting.m */; };
 		7115099E22DEA0C900256219 /* DetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7115099D22DEA0C900256219 /* DetailsViewController.m */; };
 		711509A122DEA5E300256219 /* Place.m in Sources */ = {isa = PBXBuildFile; fileRef = 711509A022DEA5E300256219 /* Place.m */; };
@@ -114,6 +116,10 @@
 		7105E0C322F4AFA400070DDC /* GoToMoreOptionsCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GoToMoreOptionsCell.m; sourceTree = "<group>"; };
 		7105E0C822F93CC000070DDC /* PopUpView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopUpView.h; sourceTree = "<group>"; };
 		7105E0C922F93CC000070DDC /* PopUpView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PopUpView.m; sourceTree = "<group>"; };
+		7105E0CB22FA500500070DDC /* PopUpViewLateral.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopUpViewLateral.h; sourceTree = "<group>"; };
+		7105E0CC22FA500500070DDC /* PopUpViewLateral.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PopUpViewLateral.m; sourceTree = "<group>"; };
+		7105E0CE22FA51F200070DDC /* PopUpViewVertical.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopUpViewVertical.h; sourceTree = "<group>"; };
+		7105E0CF22FA51F200070DDC /* PopUpViewVertical.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PopUpViewVertical.m; sourceTree = "<group>"; };
 		7115099922DE923E00256219 /* APITesting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APITesting.h; sourceTree = "<group>"; };
 		7115099A22DE923E00256219 /* APITesting.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = APITesting.m; sourceTree = "<group>"; };
 		7115099C22DEA0C900256219 /* DetailsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DetailsViewController.h; sourceTree = "<group>"; };
@@ -412,12 +418,16 @@
 				7105E0C322F4AFA400070DDC /* GoToMoreOptionsCell.m */,
 				C072BB2822F361AB009582DD /* TravelView.h */,
 				C072BB2922F361AB009582DD /* TravelView.m */,
-				7105E0C822F93CC000070DDC /* PopUpView.h */,
-				7105E0C922F93CC000070DDC /* PopUpView.m */,
 				C02BC3FF22F8F5D000448A33 /* ScheduleEventView.h */,
 				C02BC40022F8F5D000448A33 /* ScheduleEventView.m */,
 				C072BB2E22F4DF8C009582DD /* TravelStepCell.h */,
 				C072BB2F22F4DF8C009582DD /* TravelStepCell.m */,
+				7105E0C822F93CC000070DDC /* PopUpView.h */,
+				7105E0C922F93CC000070DDC /* PopUpView.m */,
+				7105E0CB22FA500500070DDC /* PopUpViewLateral.h */,
+				7105E0CC22FA500500070DDC /* PopUpViewLateral.m */,
+				7105E0CE22FA51F200070DDC /* PopUpViewVertical.h */,
+				7105E0CF22FA51F200070DDC /* PopUpViewVertical.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -704,6 +714,7 @@
 				257D2D9E22E6810A00694AC0 /* SlideMenuUIView.m in Sources */,
 				7105E0CA22F93CC000070DDC /* PopUpView.m in Sources */,
 				C041D29522ED09980038CA18 /* EditPlaceViewController.m in Sources */,
+				7105E0CD22FA500500070DDC /* PopUpViewLateral.m in Sources */,
 				71258F1322E25DFA00B0CEA0 /* Schedule.m in Sources */,
 				C06B582222DE7C2500631EF6 /* MoreOptionViewController.m in Sources */,
 				C06B57E922DD019C00631EF6 /* main.m in Sources */,
@@ -713,6 +724,7 @@
 				C041D29822ED09C50038CA18 /* EditCell.m in Sources */,
 				C06B57DB22DD019C00631EF6 /* AppDelegate.m in Sources */,
 				257D2D8F22DFCF1100694AC0 /* HomeCollectionViewController.m in Sources */,
+				7105E0D022FA51F200070DDC /* PopUpViewVertical.m in Sources */,
 				C0BBF31D22E78FEE00EE14D2 /* PlaceView.m in Sources */,
 				7105E0BE22F2660400070DDC /* PlaceWebsiteViewController.m in Sources */,
 				C06B581822DE326A00631EF6 /* BDBOAuth1SessionManager+SFAuthenticationSession.m in Sources */,

--- a/Travel Scheduler/View Controllers/HomeCollectionViewController.h
+++ b/Travel Scheduler/View Controllers/HomeCollectionViewController.h
@@ -9,7 +9,8 @@
 #import <UIKit/UIKit.h>
 #import "Place.h"
 #import "SlideMenuUIView.h"
-#import "PopUpView.h"
+#import "PopUpViewLateral.h"
+#import "PopUpViewVertical.h"
 #import "Place.h"
 #import <GIFProgressHUD.h>
 
@@ -37,7 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) bool menuViewShow;
 @property (nonatomic) bool hasFirstSchedule;
 @property (nonatomic) bool isScheduleUpToDate;
-@property (nonatomic, strong) PopUpView *errorPopUpView;
+@property (nonatomic, strong) PopUpViewLateral *errorPopUpViewLateral;
+@property (nonatomic, strong) PopUpViewVertical *errorPopUpViewVertical;
 @property (strong, nonatomic) GIFProgressHUD *hud;
 @end
 

--- a/Travel Scheduler/View Controllers/HomeCollectionViewController.m
+++ b/Travel Scheduler/View Controllers/HomeCollectionViewController.m
@@ -278,7 +278,7 @@ static int kTableViewBottomSpace = 100;
         [self.arrayOfSelectedPlaces removeObject:place];
     } else {
         if(![self checkForPlaceSelectionOverloadOnPlace:place]) {
-            [self makeLateralPopUpViewWithMessage:@"You have selected too many places!"];
+            [self makeLateralPopUpViewWithMessage:@"You have selected too many places!" withAnimations:YES];
             return;
         }
         place.selected = YES;
@@ -353,10 +353,9 @@ static int kTableViewBottomSpace = 100;
 
 - (void)makeSchedule
 {
+    //[self.scheduleButton setTitle:@"Loading..." forState:UIControlStateSelected];
     if(self.arrayOfSelectedPlaces.count > 0) {
-        [self showHud];
         [[[[self.tabBarController tabBar]items]objectAtIndex:1]setEnabled:TRUE];
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         ScheduleViewController *destView = (ScheduleViewController *)[[self.tabBarController.viewControllers objectAtIndex:1] topViewController];
         bool isFirstSchedule = NO;
           if(destView.selectedPlacesArray == nil) {
@@ -375,10 +374,6 @@ static int kTableViewBottomSpace = 100;
         [self.arrayOfSelectedPlacesCurrentlyOnSchedule addObjectsFromArray:self.arrayOfSelectedPlaces];
         [self setStateOfCreateScheduleButton];
         [self.tabBarController setSelectedIndex: 1];
-        dispatch_async(dispatch_get_main_queue(), ^{
-                [self.hud hideWithAnimation:YES];
-            });
-        });
     }
 }
 
@@ -433,7 +428,7 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
     
 #pragma mark - Pop up view methods
 
-- (void) makeLateralPopUpViewWithMessage:(NSString *)message
+- (void)makeLateralPopUpViewWithMessage:(NSString *)message withAnimations:(bool)hasAnimation
 {
     if(self.errorPopUpViewLateral == nil) {
         self.errorPopUpViewLateral = [[PopUpViewLateral alloc] initWithMessage:message];
@@ -441,17 +436,22 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
         self.errorPopUpViewLateral.messageString = message;
     }
     self.errorPopUpViewLateral.delegate = self;
-    int popWidth = (4 * self.view.frame.size.width) / 5;
+    int popWidth = self.view.frame.size.width - 10;
     int popHeight = 75;
     int popYCoord = self.homeTable.frame.origin.y + 100;
+    if(hasAnimation) {
     self.errorPopUpViewLateral.frame = CGRectMake(-popWidth, popYCoord, popWidth, popHeight);
     [self.view addSubview:self.errorPopUpViewLateral];
     [UIView animateWithDuration:0.75 animations:^{
         self.errorPopUpViewLateral.frame = CGRectMake(0, popYCoord, popWidth, popHeight);
     }];
+    } else {
+        self.errorPopUpViewLateral.frame = CGRectMake(0, popYCoord, popWidth, popHeight);
+        //[self.view addSubview:self.errorPopUpViewLateral];
+    }
 }
 
-- (void) makeVerticalPopUpViewWithMessage:(NSString *)message
+- (void)makeVerticalPopUpViewWithMessage:(NSString *)message
 {
     if(self.errorPopUpViewVertical == nil) {
         self.errorPopUpViewVertical = [[PopUpViewVertical alloc] initWithMessage:message];
@@ -459,7 +459,7 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
         self.errorPopUpViewVertical.messageString = message;
     }
     self.errorPopUpViewVertical.delegate = self;
-    int popWidth = (4 * self.view.frame.size.width) / 5;
+    int popWidth = self.view.frame.size.width - 10;
     int popHeight = 75 * 2;
     int popYCoord = self.homeTable.frame.origin.y + 100;
     self.errorPopUpViewVertical.frame = CGRectMake(-popWidth, popYCoord, popWidth, popHeight);
@@ -500,22 +500,7 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
 {
   [self dismissModalViewControllerAnimated:YES];
 }
-#pragma mark - Methods for the llama HUD
-- (void)showHud
-{
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.hud = [GIFProgressHUD showHUDWithGIFName:@"random_50fps" title:@"Amazing choices!" detailTitle:@"Calculating the best schedule for you" addedToView:self.view animated:YES];
-        self.hud.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.5];
-        self.hud.containerColor = [UIColor colorWithRed:0.37 green:0.15 blue:0.8 alpha:1];
-        self.hud.containerCornerRadius = 5;
-        self.hud.scaleFactor = 5.0;
-        self.hud.minimumPadding = 16;
-        self.hud.titleColor = [UIColor whiteColor];
-        self.hud.detailTitleColor = [UIColor whiteColor];
-        self.hud.titleFont = [UIFont fontWithName:@"Gotham-Light" size:20];
-        self.hud.detailTitleFont = [UIFont fontWithName:@"Gotham-Light" size:16];
-    });
-}
+
 @end
 
 

--- a/Travel Scheduler/View Controllers/HomeCollectionViewController.m
+++ b/Travel Scheduler/View Controllers/HomeCollectionViewController.m
@@ -437,7 +437,7 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
     }
     self.errorPopUpViewLateral.delegate = self;
     int popWidth = self.view.frame.size.width - 10;
-    int popHeight = 50;
+    int popHeight = 75;
     int popYCoord = self.homeTable.frame.origin.y + 100;
     self.errorPopUpViewLateral.frame = CGRectMake(-popWidth, popYCoord, popWidth, popHeight);
     [self.view addSubview:self.errorPopUpViewLateral];
@@ -455,7 +455,7 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
     }
     self.errorPopUpViewVertical.delegate = self;
     int popWidth = self.view.frame.size.width - 10;
-    int popHeight = 75 * 2;
+    int popHeight = 110;
     int popYCoord = self.homeTable.frame.origin.y + 100;
     self.errorPopUpViewVertical.frame = CGRectMake(-popWidth, popYCoord, popWidth, popHeight);
     [self.view addSubview:self.errorPopUpViewVertical];

--- a/Travel Scheduler/View Controllers/HomeCollectionViewController.m
+++ b/Travel Scheduler/View Controllers/HomeCollectionViewController.m
@@ -278,7 +278,7 @@ static int kTableViewBottomSpace = 100;
         [self.arrayOfSelectedPlaces removeObject:place];
     } else {
         if(![self checkForPlaceSelectionOverloadOnPlace:place]) {
-            [self makeLateralPopUpViewWithMessage:@"You have selected too many places!" withAnimations:YES];
+            [self makeLateralPopUpViewWithMessage:@"You have selected too many places!"];
             return;
         }
         place.selected = YES;
@@ -428,7 +428,7 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
     
 #pragma mark - Pop up view methods
 
-- (void)makeLateralPopUpViewWithMessage:(NSString *)message withAnimations:(bool)hasAnimation
+- (void)makeLateralPopUpViewWithMessage:(NSString *)message
 {
     if(self.errorPopUpViewLateral == nil) {
         self.errorPopUpViewLateral = [[PopUpViewLateral alloc] initWithMessage:message];
@@ -437,18 +437,13 @@ for(int outerIndex = 1; outerIndex < (int)arrayToBeSorted.count; outerIndex++) {
     }
     self.errorPopUpViewLateral.delegate = self;
     int popWidth = self.view.frame.size.width - 10;
-    int popHeight = 75;
+    int popHeight = 50;
     int popYCoord = self.homeTable.frame.origin.y + 100;
-    if(hasAnimation) {
     self.errorPopUpViewLateral.frame = CGRectMake(-popWidth, popYCoord, popWidth, popHeight);
     [self.view addSubview:self.errorPopUpViewLateral];
     [UIView animateWithDuration:0.75 animations:^{
         self.errorPopUpViewLateral.frame = CGRectMake(0, popYCoord, popWidth, popHeight);
     }];
-    } else {
-        self.errorPopUpViewLateral.frame = CGRectMake(0, popYCoord, popWidth, popHeight);
-        //[self.view addSubview:self.errorPopUpViewLateral];
-    }
 }
 
 - (void)makeVerticalPopUpViewWithMessage:(NSString *)message

--- a/Travel Scheduler/Views/DetailHeaderCell.m
+++ b/Travel Scheduler/Views/DetailHeaderCell.m
@@ -251,11 +251,13 @@ static void setButtonState(UIButton *button, Place *place)
     self.arrayOfStarImageViews = [[NSMutableArray alloc] init];
     self.arrayOfTypeLabels = [[NSMutableArray alloc] init];
     [self customLayouts];
+    dispatch_async(dispatch_get_main_queue(), ^{
     self.smallMapView = [[MKMapView alloc] initWithFrame:self.mapView.frame];
     [self loadMapView];
     self.mapView = self.smallMapView;
     [self.contentView addSubview:self.mapView];
-    int height = self.mapView.frame.origin.y + self.mapView.frame.size.height + 40;
+    });
+    int height = self.goingButton.frame.origin.y + self.goingButton.frame.size.height + 50;
     self.contentView.frame = CGRectMake(0, 0, self.width, height);
     return self;
 }

--- a/Travel Scheduler/Views/PopUpView.h
+++ b/Travel Scheduler/Views/PopUpView.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) UILabel *messageLabel;
 @property (strong, nonatomic) NSString *messageString;
 @property (strong, nonatomic) UIImageView *imageView;
-//@property (strong, nonatomic) UIButton *dismissButton;
     
 - (instancetype)initWithMessage:(NSString *)message;
 @end

--- a/Travel Scheduler/Views/PopUpView.h
+++ b/Travel Scheduler/Views/PopUpView.h
@@ -10,20 +10,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol PopUpViewDelegate;
-
 @interface PopUpView : UIView
 @property (strong, nonatomic) UILabel *messageLabel;
 @property (strong, nonatomic) NSString *messageString;
 @property (strong, nonatomic) UIImageView *imageView;
-@property (strong, nonatomic) UIButton *dismissButton;
-@property (weak, nonatomic) id<PopUpViewDelegate> delegate;
+//@property (strong, nonatomic) UIButton *dismissButton;
     
 - (instancetype)initWithMessage:(NSString *)message;
-@end
-
-@protocol PopUpViewDelegate
-- (void)didTapDismissPopUp;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Travel Scheduler/Views/PopUpView.m
+++ b/Travel Scheduler/Views/PopUpView.m
@@ -27,13 +27,6 @@ static void instantiateMessageLabel(UILabel *messageLabel, NSString *messageStri
     [messageLabel sizeToFit];
 }
 
-//static void instantiateDismissButton(UIButton *button)
-//{
-//    [button.titleLabel setFont:[UIFont fontWithName:@"Gotham-Light" size:16]];
-//    [button setTitle:@"OK" forState:UIControlStateNormal];
-//    button.titleLabel.textColor = [UIColor whiteColor];
-//}
-
 @implementation PopUpView
 
 - (instancetype)initWithMessage:(NSString *)message
@@ -53,11 +46,6 @@ static void instantiateMessageLabel(UILabel *messageLabel, NSString *messageStri
     self.messageLabel = [[UILabel alloc] init];
     instantiateMessageLabel(self.messageLabel, self.messageString);
     [self addSubview:self.messageLabel];
-    
-//    self.dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
-//    instantiateDismissButton(self.dismissButton);
-//    [self.dismissButton addTarget:self action:@selector(didTapDismiss) forControlEvents:UIControlEventTouchUpInside];
-//    [self addSubview:self.dismissButton];
 
     return self;
 }
@@ -72,12 +60,5 @@ static void instantiateMessageLabel(UILabel *messageLabel, NSString *messageStri
     int horizontalPadding = 5;
     self.imageView.frame = CGRectMake(horizontalPadding,(self.frame.size.height - imageWidth)/2,imageWidth,imageWidth);
     self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,0, 2 * imageWidth, self.frame.size.height);
-//    self.dismissButton.frame = CGRectMake((self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems), 0, self.frame.size.width - (self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems) - spaceBetweenItems , self.frame.size.height);
 }
-    
-//- (void)didTapDismiss
-//{
-//    [self.delegate didTapDismissPopUp];
-//}
-
 @end

--- a/Travel Scheduler/Views/PopUpView.m
+++ b/Travel Scheduler/Views/PopUpView.m
@@ -27,12 +27,12 @@ static void instantiateMessageLabel(UILabel *messageLabel, NSString *messageStri
     [messageLabel sizeToFit];
 }
 
-static void instantiateDismissButton(UIButton *button)
-{
-    [button.titleLabel setFont:[UIFont fontWithName:@"Gotham-Light" size:16]];
-    [button setTitle:@"OK" forState:UIControlStateNormal];
-    button.titleLabel.textColor = [UIColor whiteColor];
-}
+//static void instantiateDismissButton(UIButton *button)
+//{
+//    [button.titleLabel setFont:[UIFont fontWithName:@"Gotham-Light" size:16]];
+//    [button setTitle:@"OK" forState:UIControlStateNormal];
+//    button.titleLabel.textColor = [UIColor whiteColor];
+//}
 
 @implementation PopUpView
 
@@ -54,10 +54,10 @@ static void instantiateDismissButton(UIButton *button)
     instantiateMessageLabel(self.messageLabel, self.messageString);
     [self addSubview:self.messageLabel];
     
-    self.dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
-    instantiateDismissButton(self.dismissButton);
-    [self.dismissButton addTarget:self action:@selector(didTapDismiss) forControlEvents:UIControlEventTouchUpInside];
-    [self addSubview:self.dismissButton];
+//    self.dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
+//    instantiateDismissButton(self.dismissButton);
+//    [self.dismissButton addTarget:self action:@selector(didTapDismiss) forControlEvents:UIControlEventTouchUpInside];
+//    [self addSubview:self.dismissButton];
 
     return self;
 }
@@ -72,12 +72,12 @@ static void instantiateDismissButton(UIButton *button)
     int horizontalPadding = 5;
     self.imageView.frame = CGRectMake(horizontalPadding,(self.frame.size.height - imageWidth)/2,imageWidth,imageWidth);
     self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,0, 2 * imageWidth, self.frame.size.height);
-    self.dismissButton.frame = CGRectMake((self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems), 0, self.frame.size.width - (self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems) - spaceBetweenItems , self.frame.size.height);
+//    self.dismissButton.frame = CGRectMake((self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems), 0, self.frame.size.width - (self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems) - spaceBetweenItems , self.frame.size.height);
 }
     
-- (void)didTapDismiss
-{
-    [self.delegate didTapDismissPopUp];
-}
+//- (void)didTapDismiss
+//{
+//    [self.delegate didTapDismissPopUp];
+//}
 
 @end

--- a/Travel Scheduler/Views/PopUpViewLateral.h
+++ b/Travel Scheduler/Views/PopUpViewLateral.h
@@ -1,0 +1,25 @@
+//
+//  PopUpViewLateral.h
+//  Travel Scheduler
+//
+//  Created by gilemos on 8/6/19.
+//  Copyright © 2019 aliu18. All rights reserved.
+//
+
+#import "PopUpView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol PopUpViewLateralDelegate;
+
+@interface PopUpViewLateral : PopUpView
+@property(weak, nonatomic)id<PopUpViewLateralDelegate> delegate;
+@property (strong, nonatomic) UIButton *dismissButton;
+@end
+
+@protocol PopUpViewLateralDelegate
+- (void)didTapDismissPopUp;
+@end
+
+
+NS_ASSUME_NONNULL_END

--- a/Travel Scheduler/Views/PopUpViewLateral.m
+++ b/Travel Scheduler/Views/PopUpViewLateral.m
@@ -1,0 +1,50 @@
+//
+//  PopUpViewLateral.m
+//  Travel Scheduler
+//
+//  Created by gilemos on 8/6/19.
+//  Copyright © 2019 aliu18. All rights reserved.
+//
+
+#import "PopUpViewLateral.h"
+
+static void instantiateDismissButton(UIButton *button)
+{
+    [button.titleLabel setFont:[UIFont fontWithName:@"Gotham-Light" size:16]];
+    [button setTitle:@"OK" forState:UIControlStateNormal];
+    button.titleLabel.textColor = [UIColor whiteColor];
+}
+
+@implementation PopUpViewLateral
+
+- (instancetype)initWithMessage:(NSString *)message
+{
+    self = [super initWithMessage:message];
+    
+    self.dismissButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    instantiateDismissButton(self.dismissButton);
+    [self.dismissButton addTarget:self action:@selector(didTapDismiss) forControlEvents:UIControlEventTouchUpInside];
+    [self addSubview:self.dismissButton];
+    
+    return self;
+}
+    
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    int imageWidth = self.frame.size.width/4;
+    if(imageWidth >= self.frame.size.height) {
+        imageWidth = self.frame.size.height - 5;
+    }
+    int spaceBetweenItems = 8;
+    int horizontalPadding = 5;
+    
+    self.dismissButton.frame = CGRectMake((self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems), 0, self.frame.size.width - (self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems) - spaceBetweenItems , self.frame.size.height);
+}
+
+- (void)didTapDismiss
+{
+    [self.delegate didTapDismissPopUp];
+}
+@end

--- a/Travel Scheduler/Views/PopUpViewLateral.m
+++ b/Travel Scheduler/Views/PopUpViewLateral.m
@@ -33,14 +33,12 @@ static void instantiateDismissButton(UIButton *button)
 {
     [super layoutSubviews];
     
-    int imageWidth = self.frame.size.width/4;
-    if(imageWidth >= self.frame.size.height) {
-        imageWidth = self.frame.size.height - 5;
-    }
     int spaceBetweenItems = 8;
-    int horizontalPadding = 5;
+    int buttonSize = 60;
+    int messageLabelXCoord = self.imageView.frame.origin.x + self.imageView.frame.size.width + spaceBetweenItems;
     
-    self.dismissButton.frame = CGRectMake((self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems), 0, self.frame.size.width - (self.messageLabel.frame.origin.x + self.messageLabel.frame.size.width + spaceBetweenItems) - spaceBetweenItems , self.frame.size.height);
+    self.dismissButton.frame = CGRectMake(self.frame.size.width - buttonSize, 0, buttonSize, self.frame.size.height);
+    self.messageLabel.frame = CGRectMake(messageLabelXCoord,0, self.frame.size.width - messageLabelXCoord - buttonSize, self.frame.size.height);
 }
 
 - (void)didTapDismiss

--- a/Travel Scheduler/Views/PopUpViewVertical.h
+++ b/Travel Scheduler/Views/PopUpViewVertical.h
@@ -1,0 +1,26 @@
+//
+//  PopUpViewVertical.h
+//  Travel Scheduler
+//
+//  Created by gilemos on 8/6/19.
+//  Copyright © 2019 aliu18. All rights reserved.
+//
+
+#import "PopUpView.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol PopUpViewVerticalDelegate;
+
+@interface PopUpViewVertical : PopUpView
+@property (strong, nonatomic)UIButton *okButton;
+@property (strong, nonatomic)UIButton *cancelButton;
+@property(weak, nonatomic)id<PopUpViewVerticalDelegate> delegate;
+@end
+
+@protocol PopUpViewVerticalDelegate
+- (void)didTapOk;
+- (void)didTapCancel;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Travel Scheduler/Views/PopUpViewVertical.m
+++ b/Travel Scheduler/Views/PopUpViewVertical.m
@@ -37,11 +37,11 @@ static void instantiateButton(UIButton *button, NSString *text)
     
 - (void)layoutSubviews
 {
-    int imageWidth = self.frame.size.height/2;
+    int imageWidth = (self.frame.size.height/2) - 15;
     int spaceBetweenItems = 8;
     int horizontalPadding = 5;
-    self.imageView.frame = CGRectMake(horizontalPadding,0,imageWidth,imageWidth);
-    self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,0, self.frame.size.width - (self.imageView.frame.origin.x + imageWidth + spaceBetweenItems) - horizontalPadding, self.frame.size.height/2);
+    self.imageView.frame = CGRectMake(horizontalPadding,5,imageWidth,imageWidth);
+    self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,0, self.frame.size.width - (self.imageView.frame.origin.x + imageWidth + spaceBetweenItems), self.frame.size.height/2);
     self.okButton.frame = CGRectMake(0, self.frame.size.height/2, self.frame.size.width/2, self.frame.size.height/2);
     self.cancelButton.frame = CGRectMake(self.frame.size.width/2, self.frame.size.height/2, self.frame.size.width/2, self.frame.size.height/2);
 }

--- a/Travel Scheduler/Views/PopUpViewVertical.m
+++ b/Travel Scheduler/Views/PopUpViewVertical.m
@@ -37,13 +37,13 @@ static void instantiateButton(UIButton *button, NSString *text)
     
 - (void)layoutSubviews
 {
-    int imageWidth = (self.frame.size.height/2) - 15;
+    int imageWidth = (2 * self.frame.size.height/3) - 15;
     int spaceBetweenItems = 8;
     int horizontalPadding = 5;
     self.imageView.frame = CGRectMake(horizontalPadding,5,imageWidth,imageWidth);
-    self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,0, self.frame.size.width - (self.imageView.frame.origin.x + imageWidth + spaceBetweenItems), self.frame.size.height/2);
-    self.okButton.frame = CGRectMake(0, self.frame.size.height/2, self.frame.size.width/2, self.frame.size.height/2);
-    self.cancelButton.frame = CGRectMake(self.frame.size.width/2, self.frame.size.height/2, self.frame.size.width/2, self.frame.size.height/2);
+    self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,10, self.frame.size.width - (self.imageView.frame.origin.x + imageWidth + spaceBetweenItems), (self.frame.size.height/2) - 10);
+    self.okButton.frame = CGRectMake(0, (2 * self.frame.size.height)/3, self.frame.size.width/2, self.frame.size.height/3);
+    self.cancelButton.frame = CGRectMake(self.frame.size.width/2, (2 * self.frame.size.height)/3, self.frame.size.width/2, self.frame.size.height/3);
 }
     
 - (void)didTapOk

--- a/Travel Scheduler/Views/PopUpViewVertical.m
+++ b/Travel Scheduler/Views/PopUpViewVertical.m
@@ -1,0 +1,59 @@
+//
+//  PopUpViewVertical.m
+//  Travel Scheduler
+//
+//  Created by gilemos on 8/6/19.
+//  Copyright © 2019 aliu18. All rights reserved.
+//
+
+#import "PopUpViewVertical.h"
+
+static void instantiateButton(UIButton *button, NSString *text)
+{
+    [button.titleLabel setFont:[UIFont fontWithName:@"Gotham-Light" size:16]];
+    [button setTitle:text forState:UIControlStateNormal];
+    button.titleLabel.textColor = [UIColor whiteColor];
+}
+
+@implementation PopUpViewVertical
+    
+    
+- (instancetype)initWithMessage:(NSString *)message
+{
+    self = [super initWithMessage:message];
+    
+    self.okButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    instantiateButton(self.okButton, @"Yeah!");
+    [self.okButton addTarget:self action:@selector(didTapOk) forControlEvents:UIControlEventTouchUpInside];
+    [self addSubview:self.okButton];
+    
+    self.cancelButton = [UIButton buttonWithType:UIButtonTypeCustom];
+    instantiateButton(self.cancelButton, @"Cancel");
+    [self.cancelButton addTarget:self action:@selector(didTapCancel) forControlEvents:UIControlEventTouchUpInside];
+    [self addSubview:self.cancelButton];
+    
+    return self;
+}
+    
+- (void)layoutSubviews
+{
+    int imageWidth = self.frame.size.height/2;
+    int spaceBetweenItems = 8;
+    int horizontalPadding = 5;
+    self.imageView.frame = CGRectMake(horizontalPadding,0,imageWidth,imageWidth);
+    self.messageLabel.frame = CGRectMake(self.imageView.frame.origin.x + imageWidth + spaceBetweenItems,0, self.frame.size.width - (self.imageView.frame.origin.x + imageWidth + spaceBetweenItems) - horizontalPadding, self.frame.size.height/2);
+    self.okButton.frame = CGRectMake(0, self.frame.size.height/2, self.frame.size.width/2, self.frame.size.height/2);
+    self.cancelButton.frame = CGRectMake(self.frame.size.width/2, self.frame.size.height/2, self.frame.size.width/2, self.frame.size.height/2);
+}
+    
+- (void)didTapOk
+{
+    [self.delegate didTapOk];
+}
+    
+- (void)didTapCancel
+{
+    [self.delegate didTapCancel];
+}
+
+@end


### PR DESCRIPTION
Hey guys! I put a waring to when the user clicks back, but, mainly, I solved some crashes that was happening. Here is what I found out

- Sometimes, the app was crashing when you went to the details view. That is because Franklin's map had to run in the main thread. I used the dispatch to make sure of it and had to change the code in the table view to readjust the size of the cell (since, before that, the height of the cell depended on the size of the map, but since not the map runs asynchronously, that could not work anymore)

- A lot of times the app was crashing because of the llama hud in the schedule. The thing is, for the hud to appear, it has to run in the main thread and all the rest has to run in the background thread. But some of Angela's things changed thread, semaphores and stuff, what messed up the thread in the app and caused freezes and crashes. For this reason, I had to remove the llama hud in that part, but now it is much faster and it is not crashing nor freezing in that part. 

- When you clicked the back button, went back and regenerated the schedule, it would take a reeealy long time to regenerate. That was because a we did not reset a boolean that made the set up schedule function to be called first.

Besides that, I changed the design of the llama warning messages and, now, we have two types of it: one with lateral buttons and one with bottom buttons. They are all "children" of the same base class that has no buttons. See if you like the way I organized the code.